### PR TITLE
Update BusyBox to 1.35.0

### DIFF
--- a/busybox/Dockerfile
+++ b/busybox/Dockerfile
@@ -1,5 +1,5 @@
-ARG busybox_image=busybox:1.34.0-glibc
-ARG debian_image=debian:buster-20210408-slim
+ARG busybox_image=busybox:1.35.0-glibc
+ARG debian_image=debian:bullseye-20221205-slim
 
 # Extract additionnal glibc files from the debian image
 FROM ${debian_image} as debian


### PR DESCRIPTION
Hello 👋 

Here is a pull request to update BusyBox to 1.35.0 to fix [CVE-2022-28391](https://nvd.nist.gov/vuln/detail/CVE-2022-28391). Debian is also updated to bullseye to be in sync with `busybox:glibc` docker image.

Thanks